### PR TITLE
fix: send empty JSON body in session.create()

### DIFF
--- a/src/opencode_ai/resources/session.py
+++ b/src/opencode_ai/resources/session.py
@@ -63,6 +63,7 @@ class SessionResource(SyncAPIResource):
         """Create a new session"""
         return self._post(
             "/session",
+            body={},
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -508,6 +509,7 @@ class AsyncSessionResource(AsyncAPIResource):
         """Create a new session"""
         return await self._post(
             "/session",
+            body={},
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),


### PR DESCRIPTION
## Summary

- `session.create()` (both sync and async) now sends `body={}` so that the HTTP request includes `Content-Type: application/json` with an empty JSON object.

## Problem

The OpenCode server's `POST /session` endpoint requires a JSON request body. When `create()` is called without any parameters, the SDK sends a POST with **no body**, causing the server to respond with `400 Malformed JSON in request body`.

### Reproduction

```python
from opencode_ai import Opencode

client = Opencode(base_url="http://127.0.0.1:4096")
session = client.session.create()  # raises BadRequestError
```

### Current workaround

```python
session = client.session.create(extra_body={})
```

## Fix

Added `body={}` to the `self._post()` calls in both `SessionResource.create()` and `AsyncSessionResource.create()`. This ensures the SDK always sends a valid empty JSON object when no session parameters (like `title` or `parentID`) are provided.