### PR TITLE
fix: omit Content-Type header when request body is empty (#40)

### DIFF
--- a/src/opencode_ai/_base_client.py
+++ b/src/opencode_ai/_base_client.py
@@ -537,6 +537,9 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             else:
                 kwargs["json"] = json_data if is_given(json_data) else None
             kwargs["files"] = files
+            # Don't send Content-Type when there's no body content
+            if not is_given(json_data) and not files:
+                headers.pop("Content-Type", None)
         else:
             headers.pop("Content-Type", None)
             kwargs.pop("data", None)


### PR DESCRIPTION
## Description

Fixes #40

### Root cause

The `default_headers` property unconditionally includes `Content-Type: application/json`. For requests with an empty body (POST/PUT/PATCH with no payload), this causes servers that parse JSON bodies to fail because they receive `Content-Type: application/json` with an empty body, which is not valid JSON.

### Fix

Only send `Content-Type: application/json` when there is actual JSON content or files in the request body. For POST/PUT/PATCH requests with no body (`json_data` is `NOT_GIVEN` and no `files`), the Content-Type header is now omitted.

### Affected endpoints

Any POST/PUT/PATCH endpoint that doesn't require a request body, e.g.:
- `client.session.create()` (no body parameters)
- Similar resource creation calls without payload

### Verification

- GET requests already popped Content-Type (existing behavior, unchanged)
- POST with body → Content-Type preserved (existing behavior)
- POST without body → Content-Type now omitted (fix)
- POST with files → Content-Type handled by multipart logic (existing behavior)
