### PR TITLE
fix: nest model_id/provider_id under model key in session chat/init API calls (#52)

### DIFF
--- a/src/opencode_ai/resources/session.py
+++ b/src/opencode_ai/resources/session.py
@@ -192,9 +192,11 @@ class SessionResource(SyncAPIResource):
             f"/session/{id}/message",
             body=maybe_transform(
                 {
-                    "model_id": model_id,
+                    "model": {
+                        "model_id": model_id,
+                        "provider_id": provider_id,
+                    },
                     "parts": parts,
-                    "provider_id": provider_id,
                     "message_id": message_id,
                     "mode": mode,
                     "system": system,
@@ -243,8 +245,10 @@ class SessionResource(SyncAPIResource):
             body=maybe_transform(
                 {
                     "message_id": message_id,
-                    "model_id": model_id,
-                    "provider_id": provider_id,
+                    "model": {
+                        "model_id": model_id,
+                        "provider_id": provider_id,
+                    },
                 },
                 session_init_params.SessionInitParams,
             ),
@@ -637,9 +641,11 @@ class AsyncSessionResource(AsyncAPIResource):
             f"/session/{id}/message",
             body=await async_maybe_transform(
                 {
-                    "model_id": model_id,
+                    "model": {
+                        "model_id": model_id,
+                        "provider_id": provider_id,
+                    },
                     "parts": parts,
-                    "provider_id": provider_id,
                     "message_id": message_id,
                     "mode": mode,
                     "system": system,
@@ -688,8 +694,10 @@ class AsyncSessionResource(AsyncAPIResource):
             body=await async_maybe_transform(
                 {
                     "message_id": message_id,
-                    "model_id": model_id,
-                    "provider_id": provider_id,
+                    "model": {
+                        "model_id": model_id,
+                        "provider_id": provider_id,
+                    },
                 },
                 session_init_params.SessionInitParams,
             ),

--- a/src/opencode_ai/types/session_chat_params.py
+++ b/src/opencode_ai/types/session_chat_params.py
@@ -9,15 +9,21 @@ from .._utils import PropertyInfo
 from .file_part_input_param import FilePartInputParam
 from .text_part_input_param import TextPartInputParam
 
-__all__ = ["SessionChatParams", "Part"]
+__all__ = ["ModelParam", "SessionChatParams", "Part"]
+
+
+class ModelParam(TypedDict, total=False):
+    """Model selection parameters nested under the ``model`` key."""
+
+    model_id: Required[Annotated[str, PropertyInfo(alias="modelID")]]
+
+    provider_id: Required[Annotated[str, PropertyInfo(alias="providerID")]]
 
 
 class SessionChatParams(TypedDict, total=False):
-    model_id: Required[Annotated[str, PropertyInfo(alias="modelID")]]
+    model: Required[ModelParam]
 
     parts: Required[Iterable[Part]]
-
-    provider_id: Required[Annotated[str, PropertyInfo(alias="providerID")]]
 
     message_id: Annotated[str, PropertyInfo(alias="messageID")]
 

--- a/src/opencode_ai/types/session_init_params.py
+++ b/src/opencode_ai/types/session_init_params.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing_extensions import Required, Annotated, TypedDict
 
 from .._utils import PropertyInfo
+from .session_chat_params import ModelParam
 
 __all__ = ["SessionInitParams"]
 
@@ -12,6 +13,4 @@ __all__ = ["SessionInitParams"]
 class SessionInitParams(TypedDict, total=False):
     message_id: Required[Annotated[str, PropertyInfo(alias="messageID")]]
 
-    model_id: Required[Annotated[str, PropertyInfo(alias="modelID")]]
-
-    provider_id: Required[Annotated[str, PropertyInfo(alias="providerID")]]
+    model: Required[ModelParam]


### PR DESCRIPTION
### Issue for this PR

Closes #52

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Python SDK sends `modelID`/`providerID` as flat top-level fields in request bodies for `session.chat()` and `session.init()`, but the OpenCode server expects them nested inside a `model` object. This causes the server to ignore model selection entirely.

**Changes:**

1. Added `ModelParam` TypedDict to `session_chat_params.py` with `model_id` and `provider_id` fields (aliased to `modelID`/`providerID`)
2. Updated `SessionChatParams` to use `model: ModelParam` instead of flat fields
3. Updated `SessionInitParams` to use `model: ModelParam` instead of flat fields
4. Updated all 4 body constructions in `session.py` (sync/async chat, sync/async init) to nest `model_id`/`provider_id` under a `model` key

Before:
```json
{ "modelID": "claude-opus-4-5-20251101", "providerID": "anthropic", "parts": [...] }
```

After:
```json
{ "model": { "providerID": "anthropic", "modelID": "claude-opus-4-5-20251101" }, "parts": [...] }
```

### How did you verify your code works?

- Syntax-verified with Python `ast.parse()` on all 3 modified files
- The `ModelParam` type is reused across both `SessionChatParams` and `SessionInitParams`, avoiding duplication
- Field aliases (`modelID`, `providerID`) are preserved through the existing `PropertyInfo` mechanism

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
